### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install
 > Install Serverless Framework globally
 
 ```shell
-$ npm install -g serverless@1.48.2
+$ npm install -g serverless@1.73.1
 ```
 
 > Install required Python packages
@@ -24,7 +24,7 @@ $ pip install -r python-packages.txt -t ./lib/python
 
 > Install required serverless plugins
 ```shell
-$ sls plugin install -n serverless-pseudo-parameters
+$ serverless plugin install -n serverless-pseudo-parameters
 ```
 
 > Deploy into AWS


### PR DESCRIPTION
upgrade the serverless framework version: you upgraded serverless.yml from 1.48.2 to 1.73.1, but readme usage stays the same. 
change ambiguous `sls` command into `serverless`: Windows PowerShell has another command named sls.